### PR TITLE
Fix: Corrected typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 COPY . /app
 WORKDIR /app
-RUN pip install -r requirement.txt
+RUN pip install -r requirements.txt
 EXPOSE $PORT
 CMD gunicorn --workers=4 --bind 0.0.0.0:$PORT app:app


### PR DESCRIPTION
Changed `requirement.txt` to `requirements.txt` in the Dockerfile to ensure dependencies are installed correctly during the Docker build process. This should resolve the deployment issue caused by the build failure.